### PR TITLE
Update deprecated QoS settings

### DIFF
--- a/py_trees_ros_viewer/utilities.py
+++ b/py_trees_ros_viewer/utilities.py
@@ -60,10 +60,10 @@ def qos_profile_latched() -> rclpy.qos.QoSProfile:
     Convenience retrieval for a latched topic (publisher / subscriber)
     """
     return rclpy.qos.QoSProfile(
-        history=rclpy.qos.QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+        history=rclpy.qos.QoSHistoryPolicy.KEEP_LAST,
         depth=1,
-        durability=rclpy.qos.QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
-        reliability=rclpy.qos.QoSReliabilityPolicy.RMW_QOS_POLICY_RELIABILITY_RELIABLE
+        durability=rclpy.qos.QoSDurabilityPolicy.TRANSIENT_LOCAL,
+        reliability=rclpy.qos.QoSReliabilityPolicy.RELIABLE
     )
 
 


### PR DESCRIPTION
This is a small update that just removes some warnings that pop up when running in ROS 2 Humble.

From searching the `rclpy` code base, it seems this change was introduced in Galactic.