### PR TITLE
Fix: Toggling between different namespaces crashes the viewer

### DIFF
--- a/py_trees_ros_viewer/backend.py
+++ b/py_trees_ros_viewer/backend.py
@@ -296,7 +296,7 @@ class Backend(qt_core.QObject):
             namespace: in which to find snapshot stream services
         """
         if self.snapshot_stream is not None:
-            console.logdebug("cancelling existing snapshot stream connection [{}][backend]".format(self.snapshot_stream_watcher))
+            console.logdebug("cancelling existing snapshot stream connection [{}][backend]".format(self.snapshot_stream))
             self.snapshot_stream.shutdown()
             self.snapshot_stream = None
         console.logdebug("creating a new snapshot stream connection [{}][backend]".format(namespace))


### PR DESCRIPTION
This is just a simple variable name change that fixes the below error that occurs whenever we try to switch between various namespaces in the viewer. This is a common scenario when we have multiple trees running. The viewer will always crash when we try to toggle between these trees.

The error:
```
File "/path/to/py_trees_ros_viewer/backend.py", line 299, in connect
console.logdebug("cancelling existing snapshot stream connection [{}] [backend]".format(self.snapshot_stream_watcher))
AttributeError:  'Backend' object has no attribute 'snapshot_stream_watcher'
```
On further examination, it looks like `snapshot_stream_watcher` is referenced only in this particular line. The same function proceeds to assign a new snapshot to the variable `self.snapshot_stream`. This must have been missed out in a refactor.
Hope this helps! 

Thank you @stonier for building and maintaining py_trees and all its associated tools & libraries!