### PR TITLE
[code] Add purple color for user-defined composites

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ it is possible to switch between streaming services via the drop-down.
 ![Select](images/select.png?raw=true "Select a Tree Stream")
 
 At a minimum, the stream will send updates to the tree graph when the tree changes
-(i.e. when any one of the behaviours modifies it's status). Additional configuration
+(i.e. when any one of the behaviours modifies its status). Additional configuration
 of the stream can be managed via the checkboxes in the top right of the window - introspect
 on the blackboard and/or request more frequent updates (useful when tracking
 blackboard changes). 

--- a/py_trees_ros_viewer/backend.py
+++ b/py_trees_ros_viewer/backend.py
@@ -335,7 +335,7 @@ class Backend(qt_core.QObject):
             'Sequence': '#FFA500',
             'Selector': '#00FFFF',
             'Parallel': '#FFFF00',
-            'Recovery': '#9070DD',
+            'Composite': '#9070DD',
             'Behaviour': '#555555',
             'Decorator': '#DDDDDD',
         }

--- a/py_trees_ros_viewer/backend.py
+++ b/py_trees_ros_viewer/backend.py
@@ -335,6 +335,7 @@ class Backend(qt_core.QObject):
             'Sequence': '#FFA500',
             'Selector': '#00FFFF',
             'Parallel': '#FFFF00',
+            'Recovery': '#9070DD',
             'Behaviour': '#555555',
             'Decorator': '#DDDDDD',
         }

--- a/py_trees_ros_viewer/conversions.py
+++ b/py_trees_ros_viewer/conversions.py
@@ -60,6 +60,8 @@ def msg_constant_to_behaviour_str(value: int) -> str:
         return 'Selector'
     elif value == py_trees_msgs.Behaviour.PARALLEL:
         return 'Parallel'
+    elif value == py_trees_msgs.Behaviour.COMPOSITE:
+        return 'Composite'
     elif value == py_trees_msgs.Behaviour.DECORATOR:
         return 'Decorator'
     elif value == py_trees_msgs.Behaviour.BEHAVIOUR:


### PR DESCRIPTION
To merge after https://github.com/splintered-reality/py_trees/pull/478

Using [this color](https://share.google/sAP9RKUUJtwOtUBYf)

:warning:  I'm not adding `Recovery` [here](https://github.com/splintered-reality/py_trees_ros_viewer/blob/devel/py_trees_ros_viewer/conversions.py#L63) because the py_trees_msgs doesn't seem to be used on ROS 2