### PR TITLE
[infra] Fix package.xml dependencies for newer Ubuntu distros

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,7 @@
 
   <exec_depend>py_trees_ros_interfaces</exec_depend>
   <exec_depend>py_trees_js</exec_depend>
-  <exec_depend>python3-qt5-bindings</exec_depend>
+  <exec_depend>python3-pyqt5</exec_depend>
   <exec_depend>python3-pyqt5.qtwebengine</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>unique_identifier_msgs</exec_depend>


### PR DESCRIPTION
started seeing buildfarm errors:

```
KeyError: "No packages available for 'python3-pyside2.qtsvg'"
```

this should fix it!